### PR TITLE
silenced outputs and fixed figaro import

### DIFF
--- a/raynest/figaro_gradient.py
+++ b/raynest/figaro_gradient.py
@@ -1,6 +1,6 @@
 try:
     from figaro.mixture import DPGMM
-    from figaro.likelihood import log_norm
+    from figaro._likelihood import log_norm
 except:
     print("FIGARO not available! Hamiltonian Monte Carlo sampling not supported!")
     pass


### PR DESCRIPTION
Fixed the import of ```log_norm``` from ```figaro._likelihood``` and silenced ```ray.init()``` and ```ray.shutdown``` default message when called with ```verbose = 0```.