### PR TITLE
Fix python 3p12 installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dependencies = [
     "matplotlib",
     "ray",
     "h5py",
-    "dill"
+    "dill",
+    "psutil",
+    "setuptools"
 ]
 
 [project.urls]


### PR DESCRIPTION
Add required dependencies to correctly install with python 3.12