### PR TITLE
Fix compilation with recent versions of Cython

### DIFF
--- a/raynest/parameter.pyx
+++ b/raynest/parameter.pyx
@@ -4,7 +4,7 @@
 # cython: language_level=3, boundscheck=False, wraparound=False, binding=True, embedsignature=True
 
 from __future__ import division
-from numpy.math cimport INFINITY
+from libc.math cimport INFINITY
 cimport numpy as np
 np.import_array()
 import numpy as np


### PR DESCRIPTION
This PR closes #6.

We simply replace import from `numpy.math` by `libc.math` as recommended by Cython.