### PR TITLE
Adjust pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,17 +23,14 @@ dependencies = [
   "numpy",
   "scipy",
   "corner",
+  "dill",
   "tqdm",
   "matplotlib",
   "ray",
   "h5py",
   "psutil",
-  "setuptools"
 ]
 
 [project.urls]
 Homepage = "https://github.com/wdpozzo/raynest"
 Repository = "https://github.com/wdpozzo/raynest"
-
-[tool.setuptools.packages.find]
-where = ["raynest"]

--- a/raynest/__init__.py
+++ b/raynest/__init__.py
@@ -16,10 +16,10 @@ __version__="1.0.2"
 from .raynest import raynest
 
 # Get the version number from git tag
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import distribution, PackageNotFoundError
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = distribution(__name__).version
+except PackageNotFoundError:
     # package is not installed
     __version__ = "dev"
 


### PR DESCRIPTION
This PR reverts minor changes to `pyproject.toml` that seem to cause installation failures with the latest versions.

Fixes #9 .